### PR TITLE
Nit: Correct wrong notation of VMware name in module-02-mtv

### DIFF
--- a/content/modules/ROOT/pages/module-02-mtv.adoc
+++ b/content/modules/ROOT/pages/module-02-mtv.adoc
@@ -94,7 +94,7 @@ Also you may ignore the Inventory server warning. It is not necessary for the re
 +
 image::module-02-mtv/04_MTV_Provider_List.png[link=self, window=blank, width=100%]
 
-. The lab is already configured with the VMWare provider named *vmware* and it is marked as a migration source.
+. The lab is already configured with the VMware provider named *vmware* and it is marked as a migration source.
 
 === Create a Migration Plan
 


### PR DESCRIPTION
Just a nit-pick! Correct `VMWare` to `VMware` in `module-02-mtv.adoc`.

https://github.com/rhpds/openshift-virt-roadshow-cnv/blob/355e02f645e4ae346689293a05e43c6cc5e529cf/content/modules/ROOT/pages/module-02-mtv.adoc?plain=1#L93

Thanks